### PR TITLE
Remove a 3rd party bind instruction

### DIFF
--- a/ThirdParty/README.md
+++ b/ThirdParty/README.md
@@ -32,10 +32,6 @@ Nie możemy zagwarantować ich poprawności oraz kompletności.
 * [6 sposobów wdrożenia Listy Ostrzeżeń CERT Polska w sieci firmowej](https://avlab.pl/lista-ostrzezen-cert-polska-6-sposobow-wdrozenia/) (avlab.pl)
 * [Blokowanie domen z listy HoleCert na Mikrotik, Pihole](https://www.certyficate.it/blokowanie-domen-z-listy-holecert-na-mikrotik/) (certyficate.it)
 
-### Bind
-
-* [RPZ z listą od CERT Polska](https://nfsec.pl/security/6286) (nfsec.pl)
-
 ### Inne rozwiązania
 
 Mimo, że CERT Polska nie wspiera zewnętrznych rozwiązań, dostarczamy listy w różnych formatach w celu uproszczenia integracji z różnymi środowiskami. Przykładowo:


### PR DESCRIPTION
Remove a third-party link, since we have our own tested solution now.

(Alternative solution: link to our own instruction instead of removing the section completely. IMO unnecessary, we link to it from the main page). 